### PR TITLE
Fix CHANGELOG anchors to $schema + indicate what happened to tabular-data-package/resource

### DIFF
--- a/content/docs/overview/changelog.md
+++ b/content/docs/overview/changelog.md
@@ -14,6 +14,10 @@ This document includes all meaningful changes made to the **Data Package standar
 
 [`$schema`](/standard/data-package/#dollar-schema) replaces the `profile` property with new extensions semantics ([#42](https://github.com/frictionlessdata/datapackage-v2-draft/pull/42)).
 
+##### Tabular Data Package (removed)
+
+The [Tabular Data Package](https://specs.frictionlessdata.io/tabular-data-package/) (`$package.profile: "tabular-data-package"`) is removed. It did not add any benefits over defining `$resource.profile: "tabular-data-resource"` for its resources, which is more modular ([#52](https://github.com/frictionlessdata/datapackage-v2-draft/pull/52)).
+
 ##### `resource.$schema` (new)
 
 [`$schema`](/standard/data-resource/#dollar-schema) replaces the `profile` property with new extensions semantics ([#42](https://github.com/frictionlessdata/datapackage-v2-draft/pull/42)). See also [resource.type](#resource-type-new).

--- a/content/docs/overview/changelog.md
+++ b/content/docs/overview/changelog.md
@@ -16,7 +16,7 @@ This document includes all meaningful changes made to the **Data Package standar
 
 ##### `resource.$schema` (new)
 
-[`$schema`](/standard/data-resource/#dollar-schema) replaces the `profile` property with new extensions semantics ([#42](https://github.com/frictionlessdata/datapackage-v2-draft/pull/42)).
+[`$schema`](/standard/data-resource/#dollar-schema) replaces the `profile` property with new extensions semantics ([#42](https://github.com/frictionlessdata/datapackage-v2-draft/pull/42)). See also [resource.type](#resource-type-new).
 
 ##### `resource.sources` (updated)
 
@@ -24,7 +24,7 @@ This document includes all meaningful changes made to the **Data Package standar
 
 ##### `resource.type` (new)
 
-[`type`](/standard/data-resource/#type) allows to specify the resource type ([#51](https://github.com/frictionlessdata/datapackage-v2-draft/pull/51)).
+[`type`](/standard/data-resource/#type) allows to specify the resource type ([#51](https://github.com/frictionlessdata/datapackage-v2-draft/pull/51)). `resource.type: "table"` replaces `resource.profile: "tabular-data-resource"`.
 
 ##### `dialect.$schema` (new)
 

--- a/content/docs/overview/changelog.md
+++ b/content/docs/overview/changelog.md
@@ -12,11 +12,11 @@ This document includes all meaningful changes made to the **Data Package standar
 
 ##### `package.$schema` (new)
 
-[`$schema`](/standard/data-package/#dollar-schema) replaced `profile` property with new extensions semantics ([#42](https://github.com/frictionlessdata/datapackage-v2-draft/pull/42)).
+[`$schema`](/standard/data-package/#dollar-schema) replaces the `profile` property with new extensions semantics ([#42](https://github.com/frictionlessdata/datapackage-v2-draft/pull/42)).
 
 ##### `resource.$schema` (new)
 
-[`$schema`](/standard/data-resource/#dollar-schema) replaced `profile` property with new extensions semantics ([#42](https://github.com/frictionlessdata/datapackage-v2-draft/pull/42)).
+[`$schema`](/standard/data-resource/#dollar-schema) replaces the `profile` property with new extensions semantics ([#42](https://github.com/frictionlessdata/datapackage-v2-draft/pull/42)).
 
 ##### `resource.sources` (updated)
 
@@ -28,7 +28,7 @@ This document includes all meaningful changes made to the **Data Package standar
 
 ##### `dialect.$schema` (new)
 
-[`$schema`](/standard/table-dialect/#dollar-schema) replaced `profile` property with new extensions semantics ([#42](https://github.com/frictionlessdata/datapackage-v2-draft/pull/42)).
+[`$schema`](/standard/table-dialect/#dollar-schema) replaces `profile` property with new extensions semantics ([#42](https://github.com/frictionlessdata/datapackage-v2-draft/pull/42)).
 
 ##### `dialect.table` (new)
 
@@ -36,7 +36,7 @@ This document includes all meaningful changes made to the **Data Package standar
 
 ##### `schema.$schema` (new)
 
-[`$schema`](/standard/table-schema/#dollar-schema) replaced `profile` property with new extensions semantics ([#42](https://github.com/frictionlessdata/datapackage-v2-draft/pull/42)).
+[`$schema`](/standard/table-schema/#dollar-schema) replace `profile` property with new extensions semantics ([#42](https://github.com/frictionlessdata/datapackage-v2-draft/pull/42)).
 
 ##### `schema.missingValues` (updated)
 
@@ -48,7 +48,7 @@ This document includes all meaningful changes made to the **Data Package standar
 
 ##### `schema.categoriesOrdered` (new)
 
-[`categoriesOrdered`](/standard/table-schema/#categoriesOrdered) adds suport for ordered categorical data for the `string` and `integer` field types ([#68](https://github.com/frictionlessdata/datapackage-v2-draft/pull/68)).
+[`categoriesOrdered`](/standard/table-schema/#categoriesOrdered) adds support for ordered categorical data for the `string` and `integer` field types ([#68](https://github.com/frictionlessdata/datapackage-v2-draft/pull/68)).
 
 ## v2.0-draft
 

--- a/content/docs/overview/changelog.md
+++ b/content/docs/overview/changelog.md
@@ -46,11 +46,11 @@ The [Tabular Data Package](https://specs.frictionlessdata.io/tabular-data-packag
 
 [`missingValues`](/standard/table-schema/#missingValues) now allow to specify labeled missingness ([#68](https://github.com/frictionlessdata/datapackage-v2-draft/pull/68)).
 
-##### `schema.categories` (new)
+##### `field.categories` (new)
 
 [`categories`](/standard/table-schema/#categories) adds support for categorical data for the `string` and `integer` field types ([#68](https://github.com/frictionlessdata/datapackage-v2-draft/pull/68)).
 
-##### `schema.categoriesOrdered` (new)
+##### `field.categoriesOrdered` (new)
 
 [`categoriesOrdered`](/standard/table-schema/#categoriesOrdered) adds support for ordered categorical data for the `string` and `integer` field types ([#68](https://github.com/frictionlessdata/datapackage-v2-draft/pull/68)).
 

--- a/content/docs/overview/changelog.md
+++ b/content/docs/overview/changelog.md
@@ -12,15 +12,15 @@ This document includes all meaningful changes made to the **Data Package standar
 
 ##### `package.$schema` (new)
 
-[`$schema`](/standard/glossary/#profile) replaced `profile` property with new extensions semantics ([#42](https://github.com/frictionlessdata/datapackage-v2-draft/pull/42)).
+[`$schema`](/standard/data-package/#dollar-schema) replaced `profile` property with new extensions semantics ([#42](https://github.com/frictionlessdata/datapackage-v2-draft/pull/42)).
 
 ##### `resource.$schema` (new)
 
-[`$schema`](/standard/glossary/#profile) replaced `profile` property with new extensions semantics ([#42](https://github.com/frictionlessdata/datapackage-v2-draft/pull/42)).
+[`$schema`](/standard/data-resource/#dollar-schema) replaced `profile` property with new extensions semantics ([#42](https://github.com/frictionlessdata/datapackage-v2-draft/pull/42)).
 
 ##### `resource.sources` (updated)
 
-[`sources`](/standard/resource/#sources) now inherits from a containing data package ([#57](https://github.com/frictionlessdata/datapackage-v2-draft/pull/57)).
+[`sources`](/standard/data-resource/#sources) now inherits from a containing data package ([#57](https://github.com/frictionlessdata/datapackage-v2-draft/pull/57)).
 
 ##### `resource.type` (new)
 
@@ -28,7 +28,7 @@ This document includes all meaningful changes made to the **Data Package standar
 
 ##### `dialect.$schema` (new)
 
-[`$schema`](/standard/glossary/#profile) replaced `profile` property with new extensions semantics ([#42](https://github.com/frictionlessdata/datapackage-v2-draft/pull/42)).
+[`$schema`](/standard/table-dialect/#dollar-schema) replaced `profile` property with new extensions semantics ([#42](https://github.com/frictionlessdata/datapackage-v2-draft/pull/42)).
 
 ##### `dialect.table` (new)
 
@@ -36,7 +36,7 @@ This document includes all meaningful changes made to the **Data Package standar
 
 ##### `schema.$schema` (new)
 
-[`$schema`](/standard/glossary/#profile) replaced `profile` property with new extensions semantics ([#42](https://github.com/frictionlessdata/datapackage-v2-draft/pull/42)).
+[`$schema`](/standard/table-schema/#dollar-schema) replaced `profile` property with new extensions semantics ([#42](https://github.com/frictionlessdata/datapackage-v2-draft/pull/42)).
 
 ##### `schema.missingValues` (updated)
 

--- a/content/docs/overview/changelog.md
+++ b/content/docs/overview/changelog.md
@@ -12,7 +12,7 @@ This document includes all meaningful changes made to the **Data Package standar
 
 ##### `package.$schema` (new)
 
-[`$schema`](/standard/data-package/#dollar-schema) replaces the `profile` property with new extensions semantics ([#42](https://github.com/frictionlessdata/datapackage-v2-draft/pull/42)).
+[`$schema`](/standard/data-package/#dollar-schema) replaces the `profile` property and allows easier extension and versioning ([#42](https://github.com/frictionlessdata/datapackage-v2-draft/pull/42)).
 
 ##### Tabular Data Package (removed)
 
@@ -20,7 +20,7 @@ The [Tabular Data Package](https://specs.frictionlessdata.io/tabular-data-packag
 
 ##### `resource.$schema` (new)
 
-[`$schema`](/standard/data-resource/#dollar-schema) replaces the `profile` property with new extensions semantics ([#42](https://github.com/frictionlessdata/datapackage-v2-draft/pull/42)). See also [resource.type](#resource-type-new).
+[`$schema`](/standard/data-resource/#dollar-schema) replaces the `profile` property and allows easier extension and versioning ([#42](https://github.com/frictionlessdata/datapackage-v2-draft/pull/42)). See also [resource.type](#resource-type-new).
 
 ##### `resource.sources` (updated)
 
@@ -32,7 +32,7 @@ The [Tabular Data Package](https://specs.frictionlessdata.io/tabular-data-packag
 
 ##### `dialect.$schema` (new)
 
-[`$schema`](/standard/table-dialect/#dollar-schema) replaces `profile` property with new extensions semantics ([#42](https://github.com/frictionlessdata/datapackage-v2-draft/pull/42)).
+[`$schema`](/standard/table-dialect/#dollar-schema) allows extension and versioning ([#42](https://github.com/frictionlessdata/datapackage-v2-draft/pull/42)).
 
 ##### `dialect.table` (new)
 
@@ -40,7 +40,7 @@ The [Tabular Data Package](https://specs.frictionlessdata.io/tabular-data-packag
 
 ##### `schema.$schema` (new)
 
-[`$schema`](/standard/table-schema/#dollar-schema) replace `profile` property with new extensions semantics ([#42](https://github.com/frictionlessdata/datapackage-v2-draft/pull/42)).
+[`$schema`](/standard/table-schema/#dollar-schema) allows extension and versioning ([#42](https://github.com/frictionlessdata/datapackage-v2-draft/pull/42)).
 
 ##### `schema.missingValues` (updated)
 

--- a/content/docs/standard/table-dialect.md
+++ b/content/docs/standard/table-dialect.md
@@ -73,7 +73,7 @@ id,name
 
 Delimited formats is a group of textual formats such as CSV and TSV. Their charactistics can be expressed the following properties:
 
-- [$schema](#schema): `https://datapackage.org/profiles/1.0/tabledialect.json` by default
+- [$schema](#dollar-schema): `https://datapackage.org/profiles/1.0/tabledialect.json` by default
 - [header](#header): `true` by default
 - [headerRows](#headerRows): `1` by default
 - [headerJoin](#headerJoin): ` ` by default
@@ -105,7 +105,7 @@ An example of a well-defined Table Dialect descriptor for a CSV format:
 
 Structured formats is a group of structured or semi-structured formats such as JSON and YAML. Their charactistics can be expressed the following properties:
 
-- [$schema](#schema): `https://datapackage.org/profiles/1.0/tabledialect.json` by default
+- [$schema](#dollar-schema): `https://datapackage.org/profiles/1.0/tabledialect.json` by default
 - [header](#header): `true` by default
 - [property](#property): undefined by default
 - [itemType](#itemType): undefined by default
@@ -115,7 +115,7 @@ Structured formats is a group of structured or semi-structured formats such as J
 
 Spreadsheet formats is a group of sheet-based formats such as Excel or ODS. Their charactistics can be expressed the following properties:
 
-- [$schema](#schema): `https://datapackage.org/profiles/1.0/tabledialect.json` by default
+- [$schema](#dollar-schema): `https://datapackage.org/profiles/1.0/tabledialect.json` by default
 - [header](#header): `true` by default
 - [headerRows](#headerRows): `1` by default
 - [headerJoin](#headerJoin): ` ` by default
@@ -128,7 +128,7 @@ Spreadsheet formats is a group of sheet-based formats such as Excel or ODS. Thei
 
 Database formats is a group of formats accessing data from databases like SQLite. Their charactistics can be expressed the following properties:
 
-- [$schema](#schema): `https://datapackage.org/profiles/1.0/tabledialect.json` by default
+- [$schema](#dollar-schema): `https://datapackage.org/profiles/1.0/tabledialect.json` by default
 - [table](#table): undefined by default
 
 ## Properties


### PR DESCRIPTION
- Fix `dollar-schema` anchors + incorrect links
- Indicate what happened to Tabular Data Package (new header) and Tabular Data Resource (as part of `resource.type`)
- `$schema` did not replace `profile` for Dialect and Schema. I don't think that property was there in v1.
- Update header for `categories/Ordered` so it is clear it is a field property.