### PR TITLE
Link properties to their definition

### DIFF
--- a/content/docs/standard/data-package.mdx
+++ b/content/docs/standard/data-package.mdx
@@ -117,7 +117,7 @@ A file containing a Data Package descriptor `MAY` have other name rather than `d
 
 ## Properties
 
-A Data Package descriptor `MUST` have `resoures` property and `SHOULD` have `name`, `id`, `licenses`, and `profile` properties.
+A Data Package descriptor `MUST` have [`resoures`](#resources) property and `SHOULD` have [`name`](#name), [`id`](#id), [`licenses`](#licenses), and `profile` properties.
 
 ### `resources` [required] {#resources}
 


### PR DESCRIPTION
`profile` is not linked because it lacks a definition (#1061)