### PR TITLE
Data Package: Reference CommonMark

### DIFF
--- a/content/docs/standard/data-package.mdx
+++ b/content/docs/standard/data-package.mdx
@@ -193,7 +193,7 @@ A `string` providing a title or one sentence description for this package
 
 ### `description`
 
-A description of the package. The description `MUST` be [markdown](http://commonmark.org/) formatted -- this also allows for simple plain text as plain text is itself valid markdown. The first paragraph (up to the first double line break) `SHOULD` be usable as summary information for the package.
+A description of the package in [CommonMark Markdown](https://spec.commonmark.org/current/) syntax. As any sequence of characters is a valid CommonMark document, this allows for simple plain text. The first paragraph `SHOULD` be separated by a blank line from following content to be usable as summary information of the package.
 
 ### `homepage`
 


### PR DESCRIPTION
The `description` is CommonMark by definition, so the word `MUST` is not approriate. The first paragraph in a CommonMarkd document does not necessarily end with two line breaks, for instance it can directly be followed by one line break and a heading! This should better be a recommendation to allow splitting it from the rest of the text without use of a full-featured Markdown parser.

fixes #1065