### PR TITLE
Improve id/DOI documentation

### DIFF
--- a/profiles/dictionary/common.yaml
+++ b/profiles/dictionary/common.yaml
@@ -22,7 +22,7 @@ id:
     a package is desired for common data handling workflows, such as updating an
     existing package. While at the level of the specification, global uniqueness
     cannot be validated, consumers using the `id` property `MUST` ensure identifiers
-    are globally unique. When using a DOI, specify the full DOI link.
+    are globally unique. When providing a DOI, it is `RECOMMENDED` to provide the full URL (e.g. `https://doi.org/10.5281/zenodo.10053903`).
   type: string
   examples:
     - |

--- a/profiles/dictionary/common.yaml
+++ b/profiles/dictionary/common.yaml
@@ -16,7 +16,7 @@ name:
 id:
   title: ID
   description: A property reserved for globally unique identifiers. Examples of
-    identifiers that are unique include UUIDs and DOI links.
+    identifiers that are unique include UUIDs and DOIs.
   context: A common usage pattern for Data Packages is as a packaging format within
     the bounds of a system or platform. In these cases, a unique identifier for
     a package is desired for common data handling workflows, such as updating an

--- a/profiles/dictionary/common.yaml
+++ b/profiles/dictionary/common.yaml
@@ -16,13 +16,13 @@ name:
 id:
   title: ID
   description: A property reserved for globally unique identifiers. Examples of
-    identifiers that are unique include UUIDs and DOIs.
+    identifiers that are unique include UUIDs and DOI links.
   context: A common usage pattern for Data Packages is as a packaging format within
     the bounds of a system or platform. In these cases, a unique identifier for
     a package is desired for common data handling workflows, such as updating an
     existing package. While at the level of the specification, global uniqueness
     cannot be validated, consumers using the `id` property `MUST` ensure identifiers
-    are globally unique.
+    are globally unique. When using a DOI, specify the full DOI link.
   type: string
   examples:
     - |


### PR DESCRIPTION
- fixes #1077

---

Refine the documentation to specify the DOI format for `id`
