### PR TITLE
docs: Fixed $schema mention in Data Package

### DIFF
--- a/content/docs/standard/data-package.mdx
+++ b/content/docs/standard/data-package.mdx
@@ -117,7 +117,7 @@ A file containing a Data Package descriptor `MAY` have other name rather than `d
 
 ## Properties
 
-A Data Package descriptor `MUST` have [`resoures`](#resources) property and `SHOULD` have [`name`](#name), [`id`](#id), [`licenses`](#licenses), and `profile` properties.
+A Data Package descriptor `MUST` have [`resoures`](#resources) property and `SHOULD` have [`name`](#name), [`id`](#id), [`licenses`](#licenses), and [`$schema`](#dollar-schema) properties.
 
 ### `resources` [required] {#resources}
 


### PR DESCRIPTION
- fixes #1061

---

I think it's a documentation bug as we don't provide separate description/json-schema for legacy properties e.g. `resource.url` but we mention them in "Backward Compatibility" aside.

So if we just update the sentence I changed in the documentation it will be as expected.
